### PR TITLE
feat(agent): add rollback support with smoke test and --rollback flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ __pycache__/
 .venv/
 venv/
 
+# Runtime state
+previous_version.txt
+
 # Logs
 logs/
 *.log

--- a/version_agent/__main__.py
+++ b/version_agent/__main__.py
@@ -1,12 +1,31 @@
 """Entry point for the version agent — run with: python -m version_agent"""
 
+import sys
+
 from .checker import check_for_api_blockers
 from .logger import log
-from .updater import update_package
+from .updater import rollback, update_package
 from .versions import get_current_pinned_version, get_installed_version, get_latest_version
 
 
+def handle_rollback():
+    """Handle the --rollback command."""
+    log("=== Rollback Requested ===")
+    try:
+        previous = rollback()
+        log(f"Successfully rolled back to {previous}")
+    except FileNotFoundError as e:
+        log(f"ROLLBACK FAILED: {e}")
+    except RuntimeError as e:
+        log(f"ROLLBACK ERROR: {e}")
+
+
 def main():
+    # Handle --rollback flag
+    if "--rollback" in sys.argv:
+        handle_rollback()
+        return
+
     log("=== Version Agent Check Started ===")
 
     current = get_current_pinned_version()
@@ -34,10 +53,16 @@ def main():
 
     log(f"No API blockers found. Updating to {latest}...")
     try:
-        update_package(latest)
+        update_package(latest, current)
         log(f"Successfully updated to {latest}")
     except RuntimeError as e:
-        log(f"ERROR: Update failed - {e}")
+        log(f"ERROR: {e}")
+        log(f"Auto-rolling back to {current}...")
+        try:
+            rollback()
+            log(f"Successfully rolled back to {current}")
+        except (FileNotFoundError, RuntimeError) as rb_err:
+            log(f"ROLLBACK ALSO FAILED: {rb_err}")
 
 
 if __name__ == "__main__":

--- a/version_agent/config.py
+++ b/version_agent/config.py
@@ -7,6 +7,7 @@ GITHUB_REPO = "teng-lin/notebooklm-py"
 
 WORKSPACE = Path(__file__).resolve().parent.parent
 PINNED_VERSION_FILE = WORKSPACE / "pinned_version.txt"
+PREVIOUS_VERSION_FILE = WORKSPACE / "previous_version.txt"
 REQUIREMENTS_FILE = WORKSPACE / "requirements.txt"
 LOG_DIR = WORKSPACE / "logs"
 

--- a/version_agent/updater.py
+++ b/version_agent/updater.py
@@ -1,13 +1,21 @@
-"""Package updater — handles safe version upgrades."""
+"""Package updater — handles safe version upgrades and rollbacks."""
 
 import subprocess
 import sys
 
-from .config import PACKAGE_NAME, PINNED_VERSION_FILE, REQUIREMENTS_FILE
+from .config import PACKAGE_NAME, PINNED_VERSION_FILE, PREVIOUS_VERSION_FILE, REQUIREMENTS_FILE
 
 
-def update_package(version: str):
-    """Install a specific version and update the pinned version tracking files."""
+def _write_version_files(version: str):
+    """Update pinned_version.txt and requirements.txt to a given version."""
+    PINNED_VERSION_FILE.write_text(f"{version}\n")
+    REQUIREMENTS_FILE.write_text(
+        f"notebooklm-py[browser]=={version}\nplaywright>=1.40.0\n"
+    )
+
+
+def _pip_install(version: str):
+    """Run pip install for a specific version. Raises RuntimeError on failure."""
     result = subprocess.run(
         [sys.executable, "-m", "pip", "install", f"{PACKAGE_NAME}[browser]=={version}"],
         capture_output=True, text=True
@@ -15,7 +23,51 @@ def update_package(version: str):
     if result.returncode != 0:
         raise RuntimeError(f"pip install failed: {result.stderr}")
 
-    PINNED_VERSION_FILE.write_text(f"{version}\n")
-    REQUIREMENTS_FILE.write_text(
-        f"notebooklm-py[browser]=={version}\nplaywright>=1.40.0\n"
+
+def smoke_test() -> bool:
+    """Verify the installed notebooklm package can be imported."""
+    result = subprocess.run(
+        [sys.executable, "-c", "import notebooklm; print(notebooklm.__version__)"],
+        capture_output=True, text=True
     )
+    return result.returncode == 0
+
+
+def update_package(version: str, current_version: str):
+    """Install a new version with backup of the current version for rollback.
+
+    Saves the current version to previous_version.txt before upgrading.
+    After install, runs a smoke test — auto-rolls back if it fails.
+    """
+    # Save current version for rollback
+    PREVIOUS_VERSION_FILE.write_text(f"{current_version}\n")
+
+    _pip_install(version)
+    _write_version_files(version)
+
+    # Smoke test: verify the new version can be imported
+    if not smoke_test():
+        raise RuntimeError(
+            f"Smoke test failed after updating to {version}. "
+            f"Run 'python -m version_agent --rollback' to revert."
+        )
+
+
+def rollback() -> str:
+    """Roll back to the previous version saved in previous_version.txt.
+
+    Returns the version that was restored.
+    Raises FileNotFoundError if no previous version exists.
+    Raises RuntimeError if pip install fails.
+    """
+    if not PREVIOUS_VERSION_FILE.exists():
+        raise FileNotFoundError("No previous version found. Nothing to roll back to.")
+
+    previous = PREVIOUS_VERSION_FILE.read_text().strip()
+    if not previous:
+        raise FileNotFoundError("previous_version.txt is empty. Nothing to roll back to.")
+
+    _pip_install(previous)
+    _write_version_files(previous)
+
+    return previous


### PR DESCRIPTION
## Summary
- Before updating, saves current version to `previous_version.txt` as a restore point
- After install, runs a smoke test (`import notebooklm`) — auto-rolls back if it fails
- Adds `--rollback` CLI flag: `python3 -m version_agent --rollback`
- Adds `previous_version.txt` to `.gitignore` (runtime state)

## Test Plan
- [x] `python3 run_agent.py` — normal flow works
- [x] `python3 -m version_agent --rollback` — gracefully handles no previous version
- [ ] On actual update: verify `previous_version.txt` is created before upgrade
- [ ] On broken update: verify auto-rollback triggers

Closes #9