### PR TITLE
feat(profiles): add multi-profile support and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,34 @@ You should see output like:
 [2026-04-04 10:23:02] Already on latest version. No update needed.
 ```
 
+## Multiple Google Accounts (Profiles)
+
+`notebooklm-py` supports multiple profiles, so you can use separate Google accounts (personal, work, school) without conflicts.
+
+### Set up a profile
+
+```bash
+# Create and authenticate a named profile
+notebooklm login --profile work
+notebooklm login --profile personal
+```
+
+Each profile stores its own session cookies at `~/.notebooklm/profiles/<name>/storage_state.json`.
+
+### List authenticated profiles
+
+```bash
+python3 -m version_agent --profiles
+```
+
+### Use a specific profile
+
+```bash
+# Run notebooklm commands with a specific profile
+notebooklm --profile work notebooks list
+notebooklm --profile personal notebooks list
+```
+
 ## Project Structure
 
 ```
@@ -81,7 +109,9 @@ Notebooklm-on-Claude/
     ├── logger.py           # Timestamped logging to file and stdout
     ├── versions.py         # Detects pinned, installed, and latest versions
     ├── checker.py          # Scans GitHub for API blockers before updating
-    └── updater.py          # Performs safe pip install and updates tracking files
+    ├── updater.py          # Safe version upgrades with rollback support
+    ├── notifier.py         # macOS desktop notifications for update events
+    └── profiles.py         # Profile listing and validation
 ```
 
 ## How the Version Agent Works
@@ -99,20 +129,28 @@ The version agent runs a safety-first update flow:
    c. Scan both for API blocker keywords:
       "blocked", "auth broken", "403", "breaking change",
       "google block", "captcha", "endpoint changed", etc.
-   d. If blockers found → SKIP update, log the reason
-   e. If clean → install new version, update pinned_version.txt
-      and requirements.txt
+   d. If blockers found → SKIP update, log the reason, send macOS notification
+   e. If clean → install new version, run smoke test (import check)
+   f. If smoke test fails → auto-rollback to previous version
+   g. If smoke test passes → update pinned_version.txt and requirements.txt
 6. Log everything to logs/version_agent.log
+7. Send macOS desktop notification on success, failure, or block
 ```
 
 You can run it manually at any time:
 
 ```bash
-# From the project root
+# Check for updates
 python3 run_agent.py
 
 # Or as a Python module
 python3 -m version_agent
+
+# Roll back to the previous version
+python3 -m version_agent --rollback
+
+# List authenticated Google profiles
+python3 -m version_agent --profiles
 ```
 
 ## Setting Up the Weekly Scheduler (macOS launchd)

--- a/version_agent/__main__.py
+++ b/version_agent/__main__.py
@@ -5,6 +5,7 @@ import sys
 from .checker import check_for_api_blockers
 from .logger import log
 from .notifier import notify
+from .profiles import list_profiles
 from .updater import rollback, update_package
 from .versions import get_current_pinned_version, get_installed_version, get_latest_version
 
@@ -21,7 +22,24 @@ def handle_rollback():
         log(f"ROLLBACK ERROR: {e}")
 
 
+def handle_profiles():
+    """Handle the --profiles command."""
+    profiles = list_profiles()
+    if not profiles:
+        print("No authenticated profiles found.")
+        print("Run 'notebooklm login --profile <name>' to create one.")
+        return
+    print(f"Authenticated profiles ({len(profiles)}):")
+    for name in profiles:
+        print(f"  - {name}")
+
+
 def main():
+    # Handle --profiles flag
+    if "--profiles" in sys.argv:
+        handle_profiles()
+        return
+
     # Handle --rollback flag
     if "--rollback" in sys.argv:
         handle_rollback()

--- a/version_agent/profiles.py
+++ b/version_agent/profiles.py
@@ -1,0 +1,21 @@
+"""Profile management — list and validate notebooklm-py profiles."""
+
+from pathlib import Path
+
+
+NOTEBOOKLM_HOME = Path.home() / ".notebooklm" / "profiles"
+
+
+def list_profiles() -> list[str]:
+    """Return a list of configured profile names."""
+    if not NOTEBOOKLM_HOME.exists():
+        return []
+    return [
+        p.name for p in NOTEBOOKLM_HOME.iterdir()
+        if p.is_dir() and (p / "storage_state.json").exists()
+    ]
+
+
+def profile_exists(name: str) -> bool:
+    """Check if a specific profile has been authenticated."""
+    return (NOTEBOOKLM_HOME / name / "storage_state.json").exists()


### PR DESCRIPTION
## Summary
- Add `profiles.py` module to list and validate authenticated notebooklm-py profiles
- Add `--profiles` CLI flag to list configured Google accounts
- Update README with multi-profile setup guide, updated project structure, and new CLI commands (rollback, profiles)

## Test Plan
- [x] `python3 -m version_agent --profiles` — lists profiles or shows setup instructions
- [x] `python3 run_agent.py` — normal flow unaffected
- [x] `python3 -m version_agent --rollback` — graceful error when no previous version

Closes #6